### PR TITLE
quote displays in divs simultaneously

### DIFF
--- a/assets/javascript/logic.js
+++ b/assets/javascript/logic.js
@@ -25,9 +25,10 @@ $("#random-quote").on("click", function () {
             quote = $("<p>").text(response[0]);
             author = $("<p>").text("-Ron Swanson");
         }   
-        $("#quote").append(quote);
-        $("#author").append(author);
     });
+    //Append quote to quote bin
+    $("#quote").append(quote);
+    $("#author").append(author);
 });
 
 //Add Quote to image


### PR DESCRIPTION
Changed the click event that appends the quote to the image so that the quote bin is no longer left blank. 